### PR TITLE
Drag and drop fix for IE9+

### DIFF
--- a/lib/directives/tree-drag.directive.ts
+++ b/lib/directives/tree-drag.directive.ts
@@ -19,7 +19,7 @@ export class TreeDragDirective implements DoCheck {
 
   @HostListener('dragstart', ['$event']) onDragStart(ev) {
     // setting the data is required by firefox
-    ev.dataTransfer.setData('text/plain', ev.target.id);
+    ev.dataTransfer.setData('text', ev.target.id);
     setTimeout(() => this.treeDraggedElement.set(this.draggedElement), 30);
   }
 


### PR DESCRIPTION
This fixes the following error in IE9 & 10: 'unexpected call to method or property access'. In short, IE doesn't support MIME types and only recognizes 'text' and 'URL' as valid data types. HTML5 supports both for backwards compatibility so this change would not break modern browsers. More deatiled explanation here: http://www.developerfusion.com/article/144828/the-html5-drag-and-drop-api/.