### PR TITLE
fix(tree-options): fix cannot read property of undefined

### DIFF
--- a/lib/models/tree-options.model.ts
+++ b/lib/models/tree-options.model.ts
@@ -75,7 +75,7 @@ export class TreeOptions {
   actionMapping: IActionMapping;
 
   constructor(private options: ITreeOptions = {}) {
-    this.actionMapping = defaultsDeep(this.options.actionMapping, defaultActionMapping);
+    this.actionMapping = defaultsDeep({}, this.options.actionMapping, defaultActionMapping);
   }
   allowDrop(element, to): boolean {
     if (this.options.allowDrop instanceof Function) {


### PR DESCRIPTION
This PR prevents:

```
Error in ./TreeNodeComponent class TreeNodeComponent - inline template:16:12 caused by: Cannot read property 'mouse' of undefined
```

and fixes #198.