### PR TITLE
Run doForAll recursively

### DIFF
--- a/lib/models/tree-node.model.ts
+++ b/lib/models/tree-node.model.ts
@@ -209,7 +209,7 @@ export class TreeNode implements ITreeNode {
   doForAll(fn: (node: ITreeNode) => any) {
     fn(this);
     if (this.children) {
-      this.children.forEach((child) => fn(child));
+      this.children.forEach((child) => child.doForAll(fn));
     }
   }
 


### PR DESCRIPTION
The targets of current `doForAll` are only children, not all descendants.
I fixed it.
