### PR TITLE
Fix TypeError: Cannot read property 'toggleActivated' of null

### DIFF
--- a/lib/models/tree-options.model.ts
+++ b/lib/models/tree-options.model.ts
@@ -10,8 +10,8 @@ export interface IActionHandler {
 }
 
 export const TREE_ACTIONS = {
-  TOGGLE_SELECTED: (tree: TreeModel, node: TreeNode, $event: any) => node.toggleActivated(),
-  TOGGLE_SELECTED_MULTI: (tree: TreeModel, node: TreeNode, $event: any) => node.toggleActivated(true),
+  TOGGLE_SELECTED: (tree: TreeModel, node: TreeNode, $event: any) => node && node.toggleActivated(),
+  TOGGLE_SELECTED_MULTI: (tree: TreeModel, node: TreeNode, $event: any) => node && node.toggleActivated(true),
   SELECT: (tree: TreeModel, node: TreeNode, $event: any) => node.setIsActive(true),
   DESELECT: (tree: TreeModel, node: TreeNode, $event: any) => node.setIsActive(false),
   FOCUS: (tree: TreeModel, node: TreeNode, $event: any) => node.focus(),


### PR DESCRIPTION
Hi,

Thanks for your work on this neat plugin. 

Set mouse 'click' option to TREE_ACTIONS.TOGGLE_EXPANDED, then click on first node in the tree, then hit "space" bar on your keyboard. An error is raised. Proposed fix may not be the correct way to fix that, I guess node should be checked before being sent to  this line where toggleActivated is called on it.

Best regards,

Greg