### PR TITLE
Set treeDraggedElement to null on drop

### DIFF
--- a/lib/directives/tree-drop.directive.ts
+++ b/lib/directives/tree-drop.directive.ts
@@ -56,6 +56,7 @@ export class TreeDropDirective {
     $event.preventDefault();
     this.onDropCallback.emit({event: $event, element: this.treeDraggedElement.get()});
     this.removeClass();
+    this.treeDraggedElement.set(null);
   }
 
   private addClass() {


### PR DESCRIPTION
TreeDraggedElement is set on dragstart in tree-drag.directive. That directive also unset the element on dragend. However, this is only done if the position for the dragend is on the same element as the dragstart. The element should be removed also when the dragging is stopped somewhere else. This fix sets the element to null in the onDrop method in tree-drop.directive.

Issue: https://github.com/500tech/angular-tree-component/issues/318