### PR TITLE
Prevent overwriting existing node ids to allow use with immutable objects

### DIFF
--- a/lib/models/tree-node.model.ts
+++ b/lib/models/tree-node.model.ts
@@ -33,7 +33,9 @@ export class TreeNode implements ITreeNode {
   get originalNode() { return this._originalNode; };
 
   constructor(public data: any, public parent: TreeNode, public treeModel: TreeModel, index: number) {
-    this.id = (this.id !== undefined && this.id !== null) ? this.id : uuid(); // Make sure there's a unique ID
+    if (this.id === undefined || this.id === null) {
+      this.id = uuid();
+    } // Make sure there's a unique id without overriding existing ids to work with immutable data structures
     this.index = index;
 
     if (this.getField('children')) {


### PR DESCRIPTION
I verified that @mikedobrin's recommended fix for issue #220 works in my use case and the result passes project tests invoked with the npm `test` script.