### PR TITLE
Removing some libraries from umd bundle and suppressing some rollup warnings

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,6 +13,19 @@ export default {
   sourceMap: true,
   external: [
     '@angular/core',
-    '@angular/common'
-  ]
+    '@angular/common',
+    'lodash',
+    'mobx', 
+    'mobx-angular'
+  ],
+  onwarn: function (warning) {
+    // ignore spurious warnings about TS generated code such as __decorate, etc.
+    if (warning.code === 'THIS_IS_UNDEFINED' || warning.message.indexOf("The 'this' keyword is equivalent to 'undefined'") > -1) { 
+      return; 
+    }
+    
+    // console.warn everything else
+    console.warn( warning.message );
+  }
+
 };


### PR DESCRIPTION
There are a variety of issues submitted due to the UMD file created by rollup being incorrect: #331, #405,  #363, #308, #303, #298, etc... (just about any issue with the 'SystemJS' label) because the CommonJS plugin for rollup did not recognize lodash's exported functions. While that can be fixed with the `namedExports` property, instead I just removed it (along with mobx and mobx-angular) from the UMD bundle since they are as dependencies in package.json. I also suppressed the (spurious?) warnings rollup issued about "'this' keyword is equivalent to undefined," as I figure they probably drowned out the warnings about the unrecognized lodash exports.

FWIW, it may be a good idea to use [rollup-plugin-auto-external](https://www.npmjs.com/package/rollup-plugin-auto-external) to automatically exclude packages that are listed as dependencies (I was going to use that, but it requires a later version of rollup).