### PR TITLE
fixes "npm run example:cli" errors

### DIFF
--- a/example/cli/package.json
+++ b/example/cli/package.json
@@ -26,7 +26,7 @@
     "zone.js": "^0.8.4"
   },
   "devDependencies": {
-    "@angular/cli": "1.0.0",
+    "@angular/cli": "1.0.4",
     "@angular/compiler-cli": "^4.0.0",
     "@types/jasmine": "2.5.38",
     "@types/node": "~6.0.60",

--- a/example/cli/src/styles.scss
+++ b/example/cli/src/styles.scss
@@ -1,2 +1,2 @@
 /* You can add global styles to this file, and also import other style files */
-@import '~angular-tree-component/dist/angular-tree-component.css';
+@import '~angular-tree-component/lib/angular-tree-component.css';

--- a/example/cli/tsconfig.json
+++ b/example/cli/tsconfig.json
@@ -15,6 +15,7 @@
     "lib": [
       "es2016",
       "dom"
-    ]
+    ],
+    "paths": { "@angular/*": ["../node_modules/@angular/*"] }
   }
 }


### PR DESCRIPTION
fixes #411 

There is css file missing in dist directory, to make it work you need to build angular-tree-component first. I made easy workaround referencing to css file from lib dir.
 