### PR TITLE
Update `doc/interfaces/_api.itreemodel.html#moveNode` parameters

### DIFF
--- a/doc/interfaces/_api_.itreemodel.html
+++ b/doc/interfaces/_api_.itreemodel.html
@@ -745,15 +745,7 @@
 									<h5>node: <a href="_api_.itreenode.html" class="tsd-signature-type">ITreeNode</a></h5>
 								</li>
 								<li>
-									<h5>to: <span class="tsd-signature-type">object</span></h5>
-									<ul class="tsd-parameters">
-										<li class="tsd-parameter">
-											<h5>index<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span></h5>
-										</li>
-										<li class="tsd-parameter">
-											<h5>node<span class="tsd-signature-symbol">: </span><a href="_api_.itreenode.html" class="tsd-signature-type">ITreeNode</a></h5>
-										</li>
-									</ul>
+									<h5>to: <a href="_api_.itreenode.html" class="tsd-signature-type">ITreeNode</a></h5>
 								</li>
 							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">any</span></h4>


### PR DESCRIPTION
I believe the documentation is out-of-date with the `TreeModel.moveNode` implementation as of v2.3.0:
https://github.com/500tech/angular-tree-component/blob/c8241882746bb0489bd129d91ed1e0faf7ce9d70/CHANGELOG.md#230-2016-11-28