### PR TITLE
Rename ngOutletContext to ngTemplateOutletContext

### DIFF
--- a/lib/components/tree-node-wrapper.component.ts
+++ b/lib/components/tree-node-wrapper.component.ts
@@ -28,7 +28,7 @@ import { TreeNode } from '../models/tree-node.model';
       </div>
       <ng-container 
         [ngTemplateOutlet]="templates.treeNodeWrapperTemplate" 
-        [ngOutletContext]="{ $implicit: node, node: node, index: index, templates: templates }">
+        [ngTemplateOutletContext]="{ $implicit: node, node: node, index: index, templates: templates }">
       </ng-container>
     `
 })

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "clean:typescript": "rimraf dist",
     "lint": "tslint lib/**/*.ts",
     "rollup": "./node_modules/.bin/rollup -c rollup.config.js dist/angular-tree-component.js -o dist/angular-tree-component.umd.js",
-    "build": "npm run lint && npm run clean:typescript && ./node_modules/.bin/ngc && npm run rollup && cp lib/angular-tree-component.css dist",
+    "build": "npm run lint && npm run clean:typescript && .\\node_modules\\.bin\\ngc && npm run rollup && cp lib/angular-tree-component.css dist",
     "example:cli2": "./node_modules/.bin/ngc && cd example/cli2 && npm install && npm install ../../ && ./node_modules/.bin/ng serve",
     "example:cli": "./node_modules/.bin/ngc && cp lib/angular-tree-component.css dist && cd example/cli && npm install && npm install ../../ && ./node_modules/.bin/ng serve",
     "example:cli:win": ".\\node_modules\\.bin\\ngc && cd example\\cli && npm install && npm install ..\\..\\ && .\\node_modules\\.bin\\ng serve",


### PR DESCRIPTION
Rename ngOutletContext to ngTemplateOutletContext. 

Fixes #467 (Angular 5 compatibility issue)