### PR TITLE
fix(NgTemplateOutlet): replace deprecated ngOutletContext with ngTemplateOutletContext

### DIFF
--- a/lib/components/tree-node-wrapper.component.ts
+++ b/lib/components/tree-node-wrapper.component.ts
@@ -28,7 +28,7 @@ import { TreeNode } from '../models/tree-node.model';
       </div>
       <ng-container 
         [ngTemplateOutlet]="templates.treeNodeWrapperTemplate" 
-        [ngOutletContext]="{ $implicit: node, node: node, index: index, templates: templates }">
+        [ngTemplateOutletContext]="{ $implicit: node, node: node, index: index, templates: templates }">
       </ng-container>
     `
 })


### PR DESCRIPTION
via: https://github.com/angular/angular/pull/18780
fixing `example/cli` & `example/cli2` is needed.