### PR TITLE
Fix dropSlotHeight null check to allow a height of 0

### DIFF
--- a/lib/models/tree-options.model.ts
+++ b/lib/models/tree-options.model.ts
@@ -138,6 +138,6 @@ export class TreeOptions {
   }
 
   get dropSlotHeight(): number {
-    return this.options.dropSlotHeight || 2;
+    return this.options.dropSlotHeight === undefined ? 2 : this.options.dropSlotHeight;
   }
 }


### PR DESCRIPTION
Use a strict check for undefined. Fixes #489 