### PR TITLE
Add hasChildrenField option to TreeOptions

### DIFF
--- a/lib/defs/api.ts
+++ b/lib/defs/api.ts
@@ -26,6 +26,17 @@ export interface ITreeState {
 
 export interface ITreeOptions {
    /**
+    * A string representing the attribute of the node that indicates whether there are child nodes.
+
+    * **Default value: `hasChildren`.**
+
+    For example, if your nodes have an `isDirectory` attribute that indicates whether there are children, use:
+    ```
+      options = { hasChildrenField: 'isDirectory' }
+    ```
+    */
+   hasChildrenField?: string;
+   /**
     * A string representing the attribute of the node that contains the array of children.
 
     * **Default value: `children`.**
@@ -74,7 +85,8 @@ export interface ITreeOptions {
     * Function for loading a node's children.
       The function receives a TreeNode, and returns a value or a promise that resolves to the node's children.
 
-      This function will be called whenever a node is expanded, the `hasChildren` field is true, and the `children` field is empty.
+      This function will be called whenever a node is expanded, the `hasChildren` (`options.hasChildrenField`)
+      field is true, and the `children` field is empty.
       The result will be loaded into the node's children attribute.
 
       Example:

--- a/lib/models/tree-node.model.ts
+++ b/lib/models/tree-node.model.ts
@@ -46,7 +46,7 @@ export class TreeNode implements ITreeNode {
 
   // helper get functions:
   get hasChildren(): boolean {
-    return !!(this.data.hasChildren || (this.children && this.children.length > 0));
+    return !!(this.data[this.options.hasChildrenField] || (this.children && this.children.length > 0));
   }
   get isCollapsed(): boolean { return !this.isExpanded; }
   get isLeaf(): boolean { return !this.hasChildren; }

--- a/lib/models/tree-options.model.ts
+++ b/lib/models/tree-options.model.ts
@@ -70,6 +70,7 @@ export interface IActionMapping {
 }
 
 export class TreeOptions {
+  get hasChildrenField(): string { return this.options.hasChildrenField || 'hasChildren'; }
   get childrenField(): string { return this.options.childrenField || 'children'; }
   get displayField(): string { return this.options.displayField || 'name'; }
   get idField(): string { return this.options.idField || 'id'; }


### PR DESCRIPTION
Allow the user to change which field is checked to determine whether a node has children.

For example, if your nodes have a `isDirectory` attribute that indicates whether there are children, use:

```typescript
options = { hasChildrenField: 'isDirectory' }
```