### PR TITLE
set mobx version to 3.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "lodash": "4.17.4",
-    "mobx": ">=3",
+    "mobx": "3.6.1",
     "mobx-angular": ">=1"
   },
   "devDependencies": {


### PR DESCRIPTION
Fix #575 

Same error happens in [mobx-angular](https://github.com/mobxjs/mobx-angular/issues/66). We should keep an eye on it.