### PR TITLE
#352 - Move drag/drop events outside the angular zone to avoid change detection

### DIFF
--- a/lib/directives/tree-drop.directive.ts
+++ b/lib/directives/tree-drop.directive.ts
@@ -1,4 +1,6 @@
-import { Directive, Output, Input, EventEmitter, HostListener, Renderer, ElementRef } from '@angular/core';
+import {
+  Directive, Output, Input, EventEmitter, HostListener, Renderer, ElementRef, NgZone, AfterViewInit, OnDestroy
+} from '@angular/core';
 import { TreeDraggedElement } from '../models/tree-dragged-element.model';
 
 const DRAG_OVER_CLASS = 'is-dragging-over';
@@ -7,11 +9,14 @@ const DRAG_DISABLED_CLASS = 'is-dragging-over-disabled';
 @Directive({
   selector: '[treeDrop]'
 })
-export class TreeDropDirective {
+export class TreeDropDirective implements AfterViewInit, OnDestroy {
   @Output('treeDrop') onDropCallback = new EventEmitter();
   @Output('treeDropDragOver') onDragOverCallback = new EventEmitter();
   @Output('treeDropDragLeave') onDragLeaveCallback = new EventEmitter();
   @Output('treeDropDragEnter') onDragEnterCallback = new EventEmitter();
+  private readonly dragOverEventHandler: (ev: DragEvent) => void;
+  private readonly dragEnterEventHandler: (ev: DragEvent) => void;
+  private readonly dragLeaveEventHandler: (ev: DragEvent) => void;
 
   private _allowDrop = (element, $event) => true;
   @Input() set treeAllowDrop(allowDrop) {
@@ -24,10 +29,29 @@ export class TreeDropDirective {
     return this._allowDrop(this.treeDraggedElement.get(), $event);
   }
 
-  constructor(private el: ElementRef, private renderer: Renderer, private treeDraggedElement: TreeDraggedElement) {
+  constructor(private el: ElementRef, private renderer: Renderer, private treeDraggedElement: TreeDraggedElement, private ngZone: NgZone) {
+      this.dragOverEventHandler = this.onDragOver.bind(this);
+      this.dragEnterEventHandler = this.onDragEnter.bind(this);
+      this.dragLeaveEventHandler = this.onDragLeave.bind(this);
   }
 
-  @HostListener('dragover', ['$event']) onDragOver($event) {
+  ngAfterViewInit() {
+    let el: HTMLElement = this.el.nativeElement;
+    this.ngZone.runOutsideAngular(() => {
+      el.addEventListener('dragover', this.dragOverEventHandler);
+      el.addEventListener('dragenter', this.dragEnterEventHandler);
+      el.addEventListener('dragleave', this.dragLeaveEventHandler);
+    });
+  }
+
+  ngOnDestroy() {
+    let el: HTMLElement = this.el.nativeElement;
+    el.removeEventListener('dragover', this.dragOverEventHandler);
+    el.removeEventListener('dragenter', this.dragEnterEventHandler);
+    el.removeEventListener('dragleave', this.dragLeaveEventHandler);
+  }
+
+  onDragOver($event) {
     if (!this.allowDrop($event)) return this.addDisabledClass();
 
     this.onDragOverCallback.emit({event: $event, element: this.treeDraggedElement.get()});
@@ -36,13 +60,13 @@ export class TreeDropDirective {
     this.addClass();
   }
 
-  @HostListener('dragenter', ['$event']) onDragEnter($event) {
+  onDragEnter($event) {
     if (!this.allowDrop($event)) return;
 
     this.onDragEnterCallback.emit({event: $event, element: this.treeDraggedElement.get()});
   }
 
-  @HostListener('dragleave', ['$event']) onDragLeave($event) {
+  onDragLeave($event) {
     if (!this.allowDrop($event)) return this.removeDisabledClass();
 
     this.onDragLeaveCallback.emit({event: $event, element: this.treeDraggedElement.get()});


### PR DESCRIPTION
Per https://github.com/500tech/angular-tree-component/issues/352#issuecomment-370184291, you can move these event listeners outside the Angular Zone to avoid change detection.  I left the ones that don't get called often, especially the `drop` event, because in that particular case, you do want change detection triggered.

This has drastically improved performance of drag/drop for me.