### PR TITLE
Optimize onChanges in tree component

### DIFF
--- a/lib/components/tree.component.ts
+++ b/lib/components/tree.component.ts
@@ -112,11 +112,13 @@ export class TreeComponent implements OnChanges {
   }
 
   ngOnChanges(changes) {
-    this.treeModel.setData({
-      options: changes.options && changes.options.currentValue,
-      nodes: changes.nodes && changes.nodes.currentValue,
-      events: pick(this, this.treeModel.eventNames)
-    });
+    if (changes.options || changes.nodes) {
+      this.treeModel.setData({
+        options: changes.options && changes.options.currentValue,
+        nodes: changes.nodes && changes.nodes.currentValue,
+        events: pick(this, this.treeModel.eventNames)
+      });
+    }
   }
 
   sizeChanged() {


### PR DESCRIPTION
`this.treeModel.setData` run every time a component input changed. It is unnecessary for example in case of the `state` input (changes of `state` caused performance issues with bigger trees).