### PR TITLE
Improved type definition of IDTypeDictionary to avoid "no implicit any" error

### DIFF
--- a/lib/defs/api.ts
+++ b/lib/defs/api.ts
@@ -2,7 +2,7 @@
  * Welcome to ng2tree
  */
 export type IDType = string | number;
-export type IDTypeDictionary = { [id: string]: boolean } | { [id: number]: boolean };
+export type IDTypeDictionary = { [id: string]: boolean, [id: number]: boolean };
 
 /**
  * See ITreeNode for documentation


### PR DESCRIPTION
This is to fix #395