### PR TITLE
Support drag & drop across lazy-loaded modules

### DIFF
--- a/example/cli/src/app/app.module.ts
+++ b/example/cli/src/app/app.module.ts
@@ -46,7 +46,7 @@ import { ContextmenuComponent } from './contextmenu/contextmenu.component';
   imports: [
     BrowserModule,
     FormsModule,
-    TreeModule,
+    TreeModule.forRoot(),
     CommonModule,
     AppRoutingModule
   ],

--- a/example/cli2/src/app/app.module.ts
+++ b/example/cli2/src/app/app.module.ts
@@ -42,7 +42,7 @@ const routes: Route[] = [
     BrowserModule,
     FormsModule,
     HttpModule,
-    TreeModule,
+    TreeModule.forRoot(),
     RouterModule.forRoot(routes, { useHash: true })
   ],
   providers: [],

--- a/example/cli4/src/app/app.module.ts
+++ b/example/cli4/src/app/app.module.ts
@@ -45,7 +45,7 @@ useStrict(true);
     BrowserModule,
     FormsModule,
     HttpModule,
-    TreeModule,
+    TreeModule.forRoot(),
     AppRoutingModule
   ],
   providers: [],

--- a/example/cli5/src/app/app.module.ts
+++ b/example/cli5/src/app/app.module.ts
@@ -44,7 +44,7 @@ import { ScrollContainerComponent } from './scrollcontainer/scrollcontainer.comp
   imports: [
     BrowserModule,
     FormsModule,
-    TreeModule,
+    TreeModule.forRoot(),
     CommonModule,
     AppRoutingModule
   ],

--- a/lib/angular-tree-component.ts
+++ b/lib/angular-tree-component.ts
@@ -1,9 +1,9 @@
-import { NgModule }      from '@angular/core';
+import { ModuleWithProviders, NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MobxAngularModule } from 'mobx-angular';
 
-import { TREE_ACTIONS, IActionMapping, IActionHandler } from './models/tree-options.model';
-import { ITreeOptions, IAllowDropFn, IAllowDragFn, ITreeState } from './defs/api';
+import { IActionHandler, IActionMapping, TREE_ACTIONS } from './models/tree-options.model';
+import { IAllowDragFn, IAllowDropFn, ITreeOptions, ITreeState } from './defs/api';
 import { KEYS } from './constants/keys';
 import { TreeModel } from './models/tree.model';
 import { TreeNode } from './models/tree-node.model';
@@ -63,11 +63,16 @@ import './polyfills';
     CommonModule,
     MobxAngularModule
   ],
-  providers: [
-    TreeDraggedElement
-  ]
+  providers: []
 })
-export class TreeModule {}
+export class TreeModule {
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: TreeModule,
+      providers: [TreeDraggedElement]
+    };
+  }
+}
 
 export {
   TreeModel,


### PR DESCRIPTION
*Breaking*: Remove `TreeDraggedElement` from the `@NgModule` `providers` array on `TreeModule` & add a `forRoot()` static method to be called when loading the library in an application's `AppModule` to resolve issue #376. 