### PR TITLE
Partial fix for memory leak

### DIFF
--- a/lib/models/tree-node.model.ts
+++ b/lib/models/tree-node.model.ts
@@ -301,6 +301,8 @@ export class TreeNode implements ITreeNode {
     if (this.handler) {
       this.handler();
     }
+    this.parent = null;
+    this.children = null;
   }
 
   setIsActive(value, multi = false) {


### PR DESCRIPTION
I found that the update method of the tree model is still causing memory to leak. Nulling out some references to the parent and children nodes that a tree node holds appears to fix most of the leaking memory. 

It looks like there may still be some leaks associated with the mobx...seemingly centered around the AutoRun directive that is used in the tree component. I am not entirely sure what is going on with that right now.