### PR TITLE
Update tree-node-collection.component.ts

### DIFF
--- a/lib/components/tree-node-collection.component.ts
+++ b/lib/components/tree-node-collection.component.ts
@@ -38,7 +38,7 @@ export class TreeNodeCollectionComponent implements OnInit, OnDestroy {
   @observable viewportNodes: TreeNode[];
 
   @computed get marginTop(): string {
-    const firstNode = this.viewportNodes && this.viewportNodes.length && this.viewportNodes[0];
+    const firstNode = this.viewportNodes && this.viewportNodes.length && this.viewportNodes[0].parent && this.viewportNodes[0];
     const relativePosition = firstNode ? firstNode.position - firstNode.parent.position - firstNode.parent.getSelfHeight() : 0;
 
     return `${relativePosition}px`;


### PR DESCRIPTION
There is a very specific situation when I have multiple expanded large trees and getting the error when remove one of them:   "[mobx] Encountered an uncaught exception that was thrown by a reaction or observer component, in: 'Reaction[t.detectChanges()] TypeError: Cannot read property 'position' of null"
Actually the error occurs in the marginTop method of TreeNodeCollectionComponent. Adding the check for this.viewportNodes[0].parent fixes it.