### PR TITLE
Firefox disable drag fix

### DIFF
--- a/lib/directives/tree-drag.directive.ts
+++ b/lib/directives/tree-drag.directive.ts
@@ -32,6 +32,11 @@ export class TreeDragDirective implements AfterViewInit, DoCheck, OnDestroy {
   }
 
   @HostListener('dragstart', ['$event']) onDragStart(ev) {
+    if (!this.treeDragEnabled) {
+      // in firefox draggable="false" isn't working
+      ev.preventDefault();
+      return false;
+    }
     // setting the data is required by firefox
     ev.dataTransfer.setData('text', ev.target.id);
     this.treeDraggedElement.set(this.draggedElement);


### PR DESCRIPTION
In firefox disabling drag (in the tree options allowDrag: false, which sets the draggable="false" attribute to the HTML node) didn't work.

source: https://stackoverflow.com/questions/26356877/html5-draggable-false-not-working-in-firefox-browser

This is the only solution I could find.