### PR TITLE
Add return type to ModuleWithProviders

### DIFF
--- a/lib/angular-tree-component.ts
+++ b/lib/angular-tree-component.ts
@@ -74,7 +74,7 @@ import './polyfills';
   providers: []
 })
 export class TreeModule {
-  static forRoot(): ModuleWithProviders {
+  static forRoot(): ModuleWithProviders<TreeModule> {
     return {
       ngModule: TreeModule,
       providers: [TreeDraggedElement]


### PR DESCRIPTION
Add return type for ModuleWithProviders to be compatible with Angular 9.1.