### PR TITLE
docs(model): correct TreeModel state subscription documentation

### DIFF
--- a/projects/docs-app/src/app/fundamentals/state-binding/state-binding.component.html
+++ b/projects/docs-app/src/app/fundamentals/state-binding/state-binding.component.html
@@ -51,5 +51,5 @@
 
 
 <h2>Using API</h2>
-<p>Alternatively, you can use <code>getState</code>, <code>setState</code> and <code>subscribe</code> on treeModel API. <code>subscribe</code> will callback a function every time state changes.</p>
+<p>Alternatively, you can use <code>getState</code>, <code>setState</code> and <code>subscribeToState</code> on TreeModel API. <code>subscribeToState</code> will callback a function every time state changes.</p>
 <code-example>{{ api }}</code-example>

--- a/projects/docs-app/src/app/fundamentals/state-binding/state-binding.component.ts
+++ b/projects/docs-app/src/app/fundamentals/state-binding/state-binding.component.ts
@@ -72,18 +72,17 @@ class MyComponent {
 
   api = `
 <tree-root
-  #tree
-  (initialize)="onInit(tree)"
+  (initialize)="onInit($event)"
   [nodes]="nodes">
 </tree-root>
 
 class MyComponent {
-  onInit(tree) {
+  onInit({treeModel}: { eventName: 'initialized'; treeModel: TreeModel }) {
     if (localStorage.treeState) {
-      tree.treeModel.setState(JSON.parse(localStorage.treeState);
+      treeModel.setState(JSON.parse(localStorage.treeState);
     }
-    tree.treeModel.subscribe((state) => {
-      localStorage.treeState = JSON.stringify(state);
+    treeModel.subscribeToState((treeState: ITreeState) => {
+      localStorage.treeState = JSON.stringify(treeState);
     });
   }
 }


### PR DESCRIPTION
Documentation incorrectly uses generic `subscribe` instead of appropriate `subscribeToState` method

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/CirclonGroup/angular-tree-component/blob/master/CONTRIBUTING.md#commit-message-guidelines
- [N/A] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Documentation references and shows example of `subscribe` method but uses signature of `subscribeToState` method.

## What is the new behavior?
Corrects references & example of generic `subscribe` to `subscribeToState` method.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
