### PR TITLE
perf: do not run change detection if there is no `mouseAction` defined

### DIFF
--- a/projects/angular-tree-component/src/lib/components/tree-node-wrapper.component.ts
+++ b/projects/angular-tree-component/src/lib/components/tree-node-wrapper.component.ts
@@ -1,5 +1,29 @@
-import { Component , Input , ViewEncapsulation } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  Input,
+  NgZone,
+  OnDestroy,
+  OnInit,
+  ViewChild,
+  ViewEncapsulation
+} from '@angular/core';
+import {
+  Subject,
+  Observable,
+  BehaviorSubject,
+  EMPTY,
+  fromEvent,
+  merge
+} from 'rxjs';
+import { map, switchMap, takeUntil } from 'rxjs/operators';
+
 import { TreeNode } from '../models/tree-node.model';
+
+interface EventWithActionName {
+  event: Event;
+  actionName: string;
+}
 
 @Component({
   selector: 'tree-node-wrapper' ,
@@ -10,13 +34,9 @@ import { TreeNode } from '../models/tree-node.model';
           <tree-node-checkbox *ngIf="node.options.useCheckbox" [node]="node"></tree-node-checkbox>
           <tree-node-expander [node]="node"></tree-node-expander>
           <div class="node-content-wrapper"
+               #nodeContentWrapper
                [class.node-content-wrapper-active]="node.isActive"
                [class.node-content-wrapper-focused]="node.isFocused"
-               (click)="node.mouseAction('click', $event)"
-               (dblclick)="node.mouseAction('dblClick', $event)"
-               (mouseover)="node.mouseAction('mouseOver', $event)"
-               (mouseout)="node.mouseAction('mouseOut', $event)"
-               (contextmenu)="node.mouseAction('contextMenu', $event)"
                (treeDrop)="node.onDrop($event)"
                (treeDropDragOver)="node.mouseAction('dragOver', $event)"
                (treeDropDragLeave)="node.mouseAction('dragLeave', $event)"
@@ -36,11 +56,94 @@ import { TreeNode } from '../models/tree-node.model';
       </ng-container>
   `
 })
-
-export class TreeNodeWrapperComponent {
+export class TreeNodeWrapperComponent implements OnInit, OnDestroy {
 
   @Input() node: TreeNode;
   @Input() index: number;
   @Input() templates: any;
 
+  /** The native `<div class="node-content-wrapper"></div>` element. */
+  @ViewChild('nodeContentWrapper', { static: false })
+  set nodeContentWrapper(
+    nodeContentWrapper: ElementRef<HTMLElement> | undefined
+  ) {
+    this.nodeContentWrapper$.next(nodeContentWrapper);
+  }
+
+  /**
+   * The subject used to store the native `<div class="node-content-wrapper"></div>` since
+   * it's located within the `ngIf` directive. It might be set asynchronously whenever the condition
+   * is met. Having subject makes the code reactive and cancellable (e.g. event listeners will be
+   * automatically removed and re-added through the `switchMap` below).
+   */
+  private nodeContentWrapper$ = new BehaviorSubject<
+    ElementRef<HTMLElement> | undefined
+  >(undefined);
+
+  private destroy$ = new Subject<void>();
+
+  constructor(private ngZone: NgZone) {}
+
+  ngOnInit(): void {
+    this.nodeContentWrapper$
+      .pipe(
+        switchMap(nodeContentWrapper =>
+          nodeContentWrapper
+            ? new Observable<EventWithActionName>(subscriber =>
+                // Caretaker note: we explicitly should call `subscribe()` within the root zone.
+                // `runOutsideAngular(() => fromEvent(...))` will just create an observable within the root zone,
+                // but `addEventListener` is called when the `fromEvent` is subscribed.
+                this.ngZone.runOutsideAngular(() =>
+                  merge<EventWithActionName>(
+                    // (click)="node.mouseAction('click', $event)"
+                    createEventObservable(nodeContentWrapper, 'click', 'click'),
+                    // (dblclick)="node.mouseAction('dblClick', $event)"
+                    createEventObservable(
+                      nodeContentWrapper,
+                      'dblclick',
+                      'dblClick'
+                    ),
+                    // (mouseover)="node.mouseAction('mouseOver', $event)"
+                    createEventObservable(
+                      nodeContentWrapper,
+                      'mouseover',
+                      'mouseOver'
+                    ),
+                    // (mouseout)="node.mouseAction('mouseOut', $event)"
+                    createEventObservable(
+                      nodeContentWrapper,
+                      'mouseout',
+                      'mouseOut'
+                    ),
+                    // (contextmenu)="node.mouseAction('contextMenu', $event)"
+                    createEventObservable(
+                      nodeContentWrapper,
+                      'contextmenu',
+                      'contextMenu'
+                    )
+                  ).subscribe(subscriber)
+                )
+              )
+            : EMPTY
+        ),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(({ actionName, event }) => {
+        this.node.mouseAction(actionName, event);
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+  }
+}
+
+function createEventObservable(
+  nodeContentWrapper: ElementRef<HTMLElement>,
+  eventName: string,
+  actionName: string
+): Observable<EventWithActionName> {
+  return fromEvent(nodeContentWrapper.nativeElement, eventName).pipe(
+    map(event => ({ event, actionName }))
+  );
 }

--- a/projects/angular-tree-component/src/lib/models/tree.model.ts
+++ b/projects/angular-tree-component/src/lib/models/tree.model.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnDestroy } from '@angular/core';
+import { Injectable, NgZone, OnDestroy } from '@angular/core';
 import { observable, computed, action, autorun } from 'mobx';
 import { Subscription } from 'rxjs';
 import { TreeNode } from './tree-node.model';
@@ -27,6 +27,8 @@ export class TreeModel implements ITreeModel, OnDestroy {
   private firstUpdate = true;
   private events: any;
   private subscriptions: Subscription[] = [];
+
+  constructor(private ngZone: NgZone) {}
 
   // events
   fireEvent(event) {
@@ -215,7 +217,7 @@ export class TreeModel implements ITreeModel, OnDestroy {
 
     this.dispose();
 
-    this.virtualRoot = new TreeNode(virtualRootConfig, null, this, 0);
+    this.virtualRoot = new TreeNode(this.ngZone, virtualRootConfig, null, this, 0);
 
     this.roots = this.virtualRoot.children;
 


### PR DESCRIPTION
The `<div class="node-content-wrapper"></div>` adds event listeners within the Angular zone.
This is one of the most widely used components. The interaction with this component causes Angular
to run change detection and usually leads to frame drops when multiple `ApplicationRef.tick()` are
run within the same rendering frame.

This commit adds event listeners for the `<div class="node-content-wrapper"></div>` outside of the Angular
zone; thus they don't trigger change detection until there's `mouseAction` is defined. There's no other
way to add event listeners outside of the Angular zone except adding them manually.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/CirclonGroup/angular-tree-component/blob/master/CONTRIBUTING.md#commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
```
[x] Refactoring (no functional changes, no api changes)
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```